### PR TITLE
docs: ajout des changelogs pour la version 1.2.6 avec nouvelles fonct…

### DIFF
--- a/changelogs/devana/v1/v1.2.6.md
+++ b/changelogs/devana/v1/v1.2.6.md
@@ -1,0 +1,67 @@
+Version 1.2.5 → 1.2.6
+
+---
+
+## ✨ Nouvelles fonctionnalités & améliorations
+
+- **Support du japonais et du coréen **:
+  - Ajout du japonais et du coréen comme langues supportées dans l'interface.
+  - Détection automatique de la langue par vote majoritaire (96,2 % de précision).
+  - Ajout du support ja/ko.
+
+- **Connecteur Magnolia (CMS) **:
+  - Nouveau connecteur pour le CMS Magnolia avec nettoyage de code, sécurisation des requêtes GraphQL et protection SSRF.
+
+- **Webhook Challenger** :
+  - Ajout d'un système de validation/test des webhooks (webhook challenger).
+
+- **API de re-embedding** :
+  - Nouvelle API permettant de relancer l'embedding de documents déjà indexés.
+
+- **Améliorations de la base de connaissances (KB)** :
+  - Affichage du propriétaire de l'agent dans les KB partagées.
+  - Ajout des permissions de propriété d'agent sur les KB.
+  - Les résultats de recherche contiennent désormais des liens directs vers les éléments.
+
+- **Tracing OpenTelemetry pour les jobs Odin** :
+  - Ajout du tracing OTel et de la gestion Redis pour les jobs Odin.
+
+- **Expiration des jobs Redis** :
+  - Ajout d'un mécanisme d'expiration pour les jobs stockés dans Redis.
+
+- **Mise à jour de l'infrastructure** :
+  - Mise à jour de Node.js de la version 20 à 22 pour le frontend.
+
+---
+
+## 🛠️ Corrections de bugs / sécurité
+
+- **Sécurité — Mises à jour CVE d'avril 2026** :
+  - Correction de plusieurs vulnérabilités identifiées dans les dépendances.
+
+- **Sécurité — Protection SSRF** :
+  - Ajout d'une allowlist CIDR pour la protection SSRF lors de la création/mise à jour de sites web.
+
+- **Correction du remplacement de mots** :
+  - Le remplacement de mots utilise désormais des lookarounds Unicode au lieu de \b, ce qui corrige les problèmes avec les caractères accentués et les mots composés.
+  - Le remplacement de mots autorise désormais la substitution par un vide (suppression) au lieu de bloquer.
+
+- **Correction des agents partagés par équipe** :
+  - Les KB partagées via un agent d'équipe s'affichent désormais correctement.
+
+- **Correction de l'upload de fichiers via l'API** :
+  - Le conversationId n'était pas sauvegardé lors de l'upload de fichiers via l'API.
+
+- **Correction de la traduction du nombre de fichiers dans une KB** :
+  - En anglais, le nombre de fichiers dans une KB affichait « 11 » au lieu du nombre réel.
+
+- **Correction du crash de l'API cron website** :
+  - Résolution d'un crash dans l'API de cron lié au crawling de sites web.
+
+- **Correction de la redirection de login** :
+  - Correction du mécanisme pour préserver l'URL réelle lors de la redirection après login.
+
+- **Correction divers** :
+  - Amélioration de l'affichage des KB et de la recherche.
+  - Correction du score des outils affiché en pourcentage du challenger (toolsScore).
+  - Amélioration de la logique de correspondance et gestion des entrées dans l'évaluation des outils.

--- a/changelogs/devana/v1/v1.2.6.md
+++ b/changelogs/devana/v1/v1.2.6.md
@@ -3,6 +3,13 @@ Version 1.2.5 → 1.2.6
 ---
 
 ## ✨ Nouvelles fonctionnalités & améliorations
+   
+- **Synthèse vocale (Text-to-Speech) via l'API**
+  - Nouvel endpoint POST /v1/audio/speech permettant de convertir les messages assistant en audio.
+  - Support de plusieurs fournisseurs TTS : OpenAI, Azure OpenAI et Piper (serveur local).
+  - Détection automatique de la langue du texte pour sélectionner le bon modèle vocal.
+  - Lecture audio intégrée directement dans l'interface de chat sur les messages de l'assistant.
+  - Configuration flexible via variables d'environnement (TTS_BASE_URL, TTS_API_KEY, TTS_MODEL_NAME TTS_API_VERSION, TTS_USE_PIPER).
 
 - **Support du japonais et du coréen **:
   - Ajout du japonais et du coréen comme langues supportées dans l'interface.


### PR DESCRIPTION
1. #1630 - april-2026-cve (CVE updates)
2. #1623 - feat-re-embedding-api
3. #1627 - fix/merge-hf3
4. #1624 - fix/ssrf-allowlist-and-website-error-handling
5. #1618 - magnolia
6. #1613 - feature/webhook-challenger
7. #1573 - 1571-bug-crash-api-cron-website
8. #1622 - fix/unicode-word-boundary-replacement
9. #1617 - otel-trace-odin-jobs
10. #1484 - 1482-bug-bug-de-traduction-sur-le-nombre-de-fichiers-dans-une-kb-en-anglais-affiche-11
11. #1616 - redis-jobs-exp-age
12. #1615 - update-task-deleted-event
13. #1606 - feat/japanese-korean-support
14. #1517 - copilot/fix-file-upload-api-issue
15. #1445 - 1433-defect-le-remplacement-de-mot-ne-permet-pas-de-remplacer-par-un-vide-suppression-au-lieu-de-substitution
16. #1605 - fix/shared-kb-agent


> Ajout du TTS dès qu'il est merge

17. #1629 - add TTS API endpoint with configurable provider support
