### PR TITLE
docs: maj health-checks pour refacto health service

### DIFF
--- a/deployment/monitoring/health-checks.md
+++ b/deployment/monitoring/health-checks.md
@@ -141,7 +141,7 @@ wget -qO- http://votre-domaine/health/services
 curl -X GET http://votre-domaine/health/service/redis
 ```
 
-2. **Exemple de script de surveillance**
+2. **Exemple de script — tous les services**
 ```bash
 #!/bin/bash
 
@@ -156,7 +156,23 @@ if [ "$status" != "healthy" ]; then
 fi
 ```
 
-3. **Configuration Crontab**
+3. **Exemple de script — un service unique**
+```bash
+#!/bin/bash
+
+SERVICE="redis"
+HEALTH_ENDPOINT="http://votre-domaine/health/service/$SERVICE"
+ALERT_EMAIL="admin@votre-domaine.com"
+
+response=$(curl -s $HEALTH_ENDPOINT)
+status=$(echo $response | jq -r '.status')
+
+if [ "$status" != "healthy" ]; then
+    echo "Service $SERVICE défaillant: $response" | mail -s "Alerte Santé ($SERVICE)" $ALERT_EMAIL
+fi
+```
+
+4. **Configuration Crontab**
 ```bash
 */5 * * * * /chemin/vers/script-surveillance.sh
 ```

--- a/deployment/monitoring/health-checks.md
+++ b/deployment/monitoring/health-checks.md
@@ -1,79 +1,129 @@
 # Documentation du Système de Surveillance des Services
 
 ## Vue d'ensemble
-Ce système de surveillance fournit des vérifications en temps réel de l'état des services d'infrastructure critiques, notamment la Base de données, Meilisearch, ChromaDB, Redis, S3 et le service de conversion PDF. Il propose à la fois une API et un tableau de bord visuel pour la surveillance du système.
+Ce système de surveillance fournit des vérifications en temps réel de l'état des services d'infrastructure critiques : Base de données (PostgreSQL), Meilisearch, ChromaDB, Redis, Odin et le stockage objet (AWS S3 ou Azure Storage selon la configuration). Il propose à la fois une API et un tableau de bord visuel pour la surveillance du système.
 
 ## Table des matières
-1. [Point d'accès API](#point-daccès-api)
-2. [Tableau de bord](#tableau-de-bord)
+1. [Points d'accès API](#points-daccès-api)
+2. [Tableau de bord](#accès-au-tableau-de-bord)
 3. [Vérifications des services](#vérifications-des-services)
 4. [Surveillance et alertes](#surveillance-et-alertes)
 5. [Dépannage](#dépannage)
 
-## Point d'accès API
+## Points d'accès API
 
-### Vérification de base
+### Vérification globale
 ```bash
 GET /health/services
 ```
+Vérifie tous les services configurés en parallèle.
 
-### Format de réponse
+### Vérification d'un service unique
+```bash
+GET /health/service/:service
+```
+Vérifie un seul service. Valeurs possibles pour `:service` : `database`, `meilisearch`, `chromaDB`, `redis`, `odin`, `s3`, `azureStorage`.
+
+> Note : `s3` et `azureStorage` ne sont disponibles que si le backend de stockage correspondant est configuré (voir [Vérifications des services](#vérification-du-stockage-objet)).
+
+### Format de réponse — `/health/services`
 ```json
 {
   "status": "healthy" | "unhealthy",
-  "timestamp": "2024-01-01T12:00:00.000Z",
-  "totalResponseTime": 235,
+  "timestamp": "2026-01-01T12:00:00.000Z",
+  "vectorBusy": false,
   "services": {
     "database": {
-      "status": "healthy" | "unhealthy",
+      "status": "healthy" | "unhealthy" | "timeout",
       "responseTime": 50,
-      "error": null | "message d'erreur"
+      "error": null
     },
     "meilisearch": {
-      "status": "healthy" | "unhealthy",
+      "status": "healthy" | "unhealthy" | "timeout",
       "responseTime": 45,
-      "error": null | "message d'erreur"
-    },
-    // ... autres services
-  }
+      "error": null
+    }
+    // ... autres services configurés
+  },
+  "vectorOperations": [
+    {
+      "id": "op-123",
+      "operation": "embedding",
+      "agentId": "agent-456",
+      "duration": 1200,
+      "details": {}
+    }
+  ]
+}
+```
+
+Champs :
+- `status` : statut global, `healthy` uniquement si **tous** les services sont `healthy`.
+- `vectorBusy` : `true` si des opérations vectorielles sont en cours.
+- `vectorOperations` : liste des opérations vectorielles en cours (vide sinon).
+- `services.<nom>.status` : `healthy`, `unhealthy` (échec) ou `timeout` (dépassement du délai).
+- `services.<nom>.responseTime` : durée en ms si `healthy`, `null` sinon.
+- `services.<nom>.error` : message d'erreur si non `healthy`, `null` sinon.
+
+### Format de réponse — `/health/service/:service`
+```json
+{
+  "service": "redis",
+  "timestamp": "2026-01-01T12:00:00.000Z",
+  "status": "healthy" | "unhealthy" | "timeout",
+  "responseTime": 12,
+  "error": null
+}
+```
+
+Si le service demandé n'existe pas (ou n'est pas configuré) :
+```json
+{
+  "status": "unknown-service",
+  "service": "foo",
+  "error": "Service \"foo\" is not configured"
 }
 ```
 
 ### Codes de statut
-- `200`: Tous les systèmes sont opérationnels
-- `500`: Un ou plusieurs services sont défaillants
+- `200` : service(s) opérationnel(s) (`status: healthy`)
+- `500` : un ou plusieurs services défaillants (`unhealthy` ou `timeout`)
+- `404` : service inconnu (endpoint unique uniquement)
 
 ## Vérifications des services
 
+Chaque vérification dispose d'un délai d'expiration (timeout). Au-delà, le service est marqué `timeout`.
+
+| Service | Sonde | Timeout |
+| --- | --- | --- |
+| `database` | Requête `SELECT 1` sur PostgreSQL | 4000 ms |
+| `meilisearch` | Création de l'index `healthtest` + recherche `test` | 4000 ms |
+| `chromaDB` | Création de la collection `healthtest` | 4000 ms |
+| `redis` | Commande `PING` | 4000 ms |
+| `odin` | GET `/api/v1/health` + vérification des workers de la queue `request` | 4000 ms |
+| `s3` | `ListBuckets` (AWS S3) | 16000 ms |
+| `azureStorage` | Vérification d'existence du conteneur Azure | 16000 ms |
+
 ### Vérification de la base de données
-- Vérifie la connexion à la base de données PostgreSQL
-- Effectue une requête simple pour vérifier l'accès en lecture
-- Seuil de temps de réponse : < 1000ms
+- Vérifie la connexion à PostgreSQL via une requête `SELECT 1`.
 
 ### Vérification de Meilisearch
-- Vérifie la connexion au serveur Meilisearch
-- Teste la création d'index et la fonctionnalité de recherche
-- Seuil de temps de réponse : < 500ms
+- Crée/récupère l'index `healthtest` puis exécute une recherche `test`.
 
 ### Vérification de ChromaDB
-- Vérifie la connexion à ChromaDB
-- Teste la création de collection
-- Seuil de temps de réponse : < 1000ms
+- Crée/récupère la collection `healthtest`.
 
 ### Vérification de Redis
-- Vérifie la connexion au serveur Redis
-- Effectue une commande PING
-- Seuil de temps de réponse : < 100ms
+- Exécute une commande `PING`.
 
-### Vérification de S3
-- Vérifie la connectivité AWS S3
-- Teste les permissions de listage des buckets
-- Seuil de temps de réponse : < 300ms
+### Vérification d'Odin
+- Appelle `GET {ODIN_API_URL}/api/v1/health` (échec si le statut HTTP n'est pas `ok`).
+- Vérifie qu'au moins un worker consomme la queue BullMQ `request` (préfixe `devana:odin`). Aucun worker ⇒ `unhealthy`.
 
-### Vérification du service PDF
-- Vérifie la disponibilité du service de conversion PDF
-- Teste le point d'accès de santé
-- Seuil de temps de réponse : < 500ms
+### Vérification du stockage objet
+Un seul backend de stockage est vérifié, selon la configuration d'environnement :
+- `s3` : actif si `AWS_S3_ACCESS_KEY_ID` est défini. Teste les permissions `ListBuckets`.
+- `azureStorage` : actif si `AZURE_STORAGE_ACCOUNT_NAME` est défini (et `AWS_S3_ACCESS_KEY_ID` absent). Vérifie l'existence du conteneur.
 
 ## Surveillance et alertes
 
@@ -86,6 +136,9 @@ curl -X GET http://votre-domaine/health/services -H "Accept: application/json"
 
 # Utilisation de wget
 wget -qO- http://votre-domaine/health/services
+
+# Vérifier un service unique
+curl -X GET http://votre-domaine/health/service/redis
 ```
 
 2. **Exemple de script de surveillance**
@@ -142,6 +195,15 @@ curl http://localhost:7700/health
 redis-cli ping
 ```
 
+4. **Problèmes Odin**
+```bash
+# Vérifier l'API Odin
+curl ${ODIN_API_URL}/api/v1/health
+
+# Si l'API répond mais le service est unhealthy :
+# vérifier qu'au moins un worker consomme la queue "request"
+```
+
 ### Étapes de récupération des services
 
 1. **Récupération base de données**
@@ -158,10 +220,9 @@ redis-cli FLUSHALL
 sudo systemctl restart redis
 ```
 
-3. **Récupération service PDF**
+3. **Récupération Odin**
 ```bash
-# Redémarrer le service
-sudo systemctl restart pdf-conversion-service
+# Redémarrer les workers Odin si la queue "request" n'a aucun consommateur
 ```
 
 ## Accès au tableau de bord
@@ -175,8 +236,8 @@ http://votre-domaine-front/health/
 
 1. **Surveillance régulière**
    - Mettre en place des vérifications automatisées toutes les 5 minutes
-   - Configurer des alertes pour les temps de réponse dépassant les seuils
-   - Surveiller les tendances pour la dégradation des performances
+   - Configurer des alertes sur les statuts `unhealthy` et `timeout`
+   - Surveiller `vectorBusy` / `vectorOperations` pour détecter une charge vectorielle anormale
 
 2. **Maintenance**
    - Rotation régulière des logs


### PR DESCRIPTION
## Contexte

La doc `deployment/monitoring/health-checks.md` était désynchronisée du service health après la refacto côté serveur (`devana.ai`, branch `refacto-healthy`, commit `a00b8e797` — *refacto health service, uniforme output api, more information by service for debug*).

## Changements

- **Nouvel endpoint** documenté : `GET /health/service/:service` (check unitaire, 404 si inconnu)
- **Liste services** corrigée : `database`, `meilisearch`, `chromaDB`, `redis`, `odin`, `s3` **ou** `azureStorage` (conditionnel env). Suppression du service « PDF » obsolète.
- **Format réponse** à jour : ajout `vectorBusy` + `vectorOperations`, statut par service peut être `timeout`, suppression de `totalResponseTime`.
- **Tableau sondes + timeouts réels** (4000ms fast / 16000ms storage).
- **Codes statut** : 200 / 500 / 404.
- Section dépannage **Odin** ajoutée.

## Note

Le code source de référence est sur la branch `refacto-healthy` (non encore mergée) du dépôt `devana.ai`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)